### PR TITLE
Crypto.Hash.BLAKE2.Internal: don't inline unsafe functions

### DIFF
--- a/src/Crypto/Hash/BLAKE2/BLAKE2b.hsc
+++ b/src/Crypto/Hash/BLAKE2/BLAKE2b.hsc
@@ -43,7 +43,7 @@ initialize :: Int
            -- ^ Output length in bytes
            -> BLAKE2bState
 initialize = initializer c_blake2b_init
-{-# INLINE initialize #-}
+{-# NOINLINE initialize #-}
 
 -- | Create a new keyed hashing state.
 initialize' :: Int
@@ -52,7 +52,7 @@ initialize' :: Int
             -- ^ Key
             -> BLAKE2bState
 initialize' = initializer' c_blake2b_init_key
-{-# INLINE initialize' #-}
+{-# NOINLINE initialize' #-}
 
 -- | Add data to the hashing state.
 update :: ByteString
@@ -61,7 +61,7 @@ update :: ByteString
        -- ^ Hashing state
        -> BLAKE2bState
 update = updater c_blake2b_update
-{-# INLINE update #-}
+{-# NOINLINE update #-}
 
 -- | Finalize the hashing state.
 finalize :: Int
@@ -70,7 +70,7 @@ finalize :: Int
          -- ^ Hashing state
          -> ByteString
 finalize = finalizer c_blake2b_final
-{-# INLINE finalize #-}
+{-# NOINLINE finalize #-}
 
 -- | Perform hashing all in one step. A common way of calling this function
 --   is @hash 64 mempty dataToHash@ for applications which do not require
@@ -83,7 +83,7 @@ hash :: Int
      -- ^ Data to hash
      -> ByteString
 hash = hasher c_blake2b
-{-# INLINE hash #-}
+{-# NOINLINE hash #-}
 
 foreign import ccall unsafe "blake2.h blake2b"
   c_blake2b :: HashFunc

--- a/src/Crypto/Hash/BLAKE2/BLAKE2bp.hsc
+++ b/src/Crypto/Hash/BLAKE2/BLAKE2bp.hsc
@@ -43,7 +43,7 @@ initialize :: Int
            -- ^ Output length in bytes
            -> BLAKE2bpState
 initialize = initializer c_blake2bp_init
-{-# INLINE initialize #-}
+{-# NOINLINE initialize #-}
 
 -- | Create a new keyed hashing state.
 initialize' :: Int
@@ -52,7 +52,7 @@ initialize' :: Int
             -- ^ Key
             -> BLAKE2bpState
 initialize' = initializer' c_blake2bp_init_key
-{-# INLINE initialize' #-}
+{-# NOINLINE initialize' #-}
 
 -- | Add data to the hashing state.
 update :: ByteString
@@ -61,7 +61,7 @@ update :: ByteString
        -- ^ Hashing state
        -> BLAKE2bpState
 update = updater c_blake2bp_update
-{-# INLINE update #-}
+{-# NOINLINE update #-}
 
 -- | Finalize the hashing state.
 finalize :: Int
@@ -70,7 +70,7 @@ finalize :: Int
          -- ^ Hashing state
          -> ByteString
 finalize = finalizer c_blake2bp_final
-{-# INLINE finalize #-}
+{-# NOINLINE finalize #-}
 
 -- | Perform hashing all in one step. A common way of calling this function
 --   is @hash 64 mempty dataToHash@ for applications which do not require
@@ -83,7 +83,7 @@ hash :: Int
      -- ^ Data to hash
      -> ByteString
 hash = hasher c_blake2bp
-{-# INLINE hash #-}
+{-# NOINLINE hash #-}
 
 foreign import ccall unsafe "blake2.h blake2bp"
   c_blake2bp :: HashFunc

--- a/src/Crypto/Hash/BLAKE2/BLAKE2s.hsc
+++ b/src/Crypto/Hash/BLAKE2/BLAKE2s.hsc
@@ -43,7 +43,7 @@ initialize :: Int
            -- ^ Output length in bytes
            -> BLAKE2sState
 initialize = initializer c_blake2s_init
-{-# INLINE initialize #-}
+{-# NOINLINE initialize #-}
 
 -- | Create a new keyed hashing state.
 initialize' :: Int
@@ -52,7 +52,7 @@ initialize' :: Int
             -- ^ Key
             -> BLAKE2sState
 initialize' = initializer' c_blake2s_init_key
-{-# INLINE initialize' #-}
+{-# NOINLINE initialize' #-}
 
 -- | Add data to the hashing state.
 update :: ByteString
@@ -61,7 +61,7 @@ update :: ByteString
        -- ^ Hashing state
        -> BLAKE2sState
 update = updater c_blake2s_update
-{-# INLINE update #-}
+{-# NOINLINE update #-}
 
 -- | Finalize the hashing state.
 finalize :: Int
@@ -70,7 +70,7 @@ finalize :: Int
          -- ^ Hashing state
          -> ByteString
 finalize = finalizer c_blake2s_final
-{-# INLINE finalize #-}
+{-# NOINLINE finalize #-}
 
 -- | Perform hashing all in one step. A common way of calling this function
 --   is @hash 32 mempty dataToHash@ for applications which do not require
@@ -83,7 +83,7 @@ hash :: Int
      -- ^ Data to hash
      -> ByteString
 hash = hasher c_blake2s
-{-# INLINE hash #-}
+{-# NOINLINE hash #-}
 
 foreign import ccall unsafe "blake2.h blake2s"
   c_blake2s :: HashFunc

--- a/src/Crypto/Hash/BLAKE2/BLAKE2sp.hsc
+++ b/src/Crypto/Hash/BLAKE2/BLAKE2sp.hsc
@@ -43,7 +43,7 @@ initialize :: Int
            -- ^ Output length in bytes
            -> BLAKE2spState
 initialize = initializer c_blake2sp_init
-{-# INLINE initialize #-}
+{-# NOINLINE initialize #-}
 
 -- | Create a new keyed hashing state.
 initialize' :: Int
@@ -52,7 +52,7 @@ initialize' :: Int
             -- ^ Key
             -> BLAKE2spState
 initialize' = initializer' c_blake2sp_init_key
-{-# INLINE initialize' #-}
+{-# NOINLINE initialize' #-}
 
 -- | Add data to the hashing state.
 update :: ByteString
@@ -61,7 +61,7 @@ update :: ByteString
        -- ^ Hashing state
        -> BLAKE2spState
 update = updater c_blake2sp_update
-{-# INLINE update #-}
+{-# NOINLINE update #-}
 
 -- | Finalize the hashing state.
 finalize :: Int
@@ -70,7 +70,7 @@ finalize :: Int
          -- ^ Hashing state
          -> ByteString
 finalize = finalizer c_blake2sp_final
-{-# INLINE finalize #-}
+{-# NOINLINE finalize #-}
 
 -- | Perform hashing all in one step. A common way of calling this function
 --   is @hash 32 mempty dataToHash@ for applications which do not require
@@ -83,7 +83,7 @@ hash :: Int
      -- ^ Data to hash
      -> ByteString
 hash = hasher c_blake2sp
-{-# INLINE hash #-}
+{-# NOINLINE hash #-}
 
 foreign import ccall unsafe "blake2.h blake2sp"
   c_blake2sp :: HashFunc

--- a/src/Crypto/Hash/BLAKE2/Internal.hs
+++ b/src/Crypto/Hash/BLAKE2/Internal.hs
@@ -67,6 +67,7 @@ initializer f outlen = unsafePerformIO $ do
     if ret == 0
     then return fptr
     else error "initialization failure"
+{-# NOINLINE initializer #-}
 
 initializer' :: Storable a
              => InitKeyFunc a
@@ -83,6 +84,7 @@ initializer' f outlen key = unsafePerformIO $ do
       if ret == 0
       then return fptr
       else error "initialization failure"
+{-# NOINLINE initializer' #-}
 
 updater :: Storable a
         => UpdateFunc a
@@ -99,6 +101,7 @@ updater f d state = unsafePerformIO $ do
         copyArray nsptr sptr 1
         void $ f nsptr dptr dlen'
   return newState
+{-# NOINLINE updater #-}
 
 finalizer :: Storable a
           => FinalFunc a
@@ -113,6 +116,7 @@ finalizer f outlen state = unsafePerformIO $ do
         let outlen' = fromIntegral outlen
         copyArray nsptr sptr 1
         void $ f nsptr optr outlen'
+{-# NOINLINE finalizer #-}
 
 hasher :: HashFunc
        -> Int
@@ -127,4 +131,4 @@ hasher h outlen key input =
             ilen'   = fromIntegral ilen
             klen'   = fromIntegral klen
         in void $ h out istr kstr outlen' ilen' klen'
-{-# INLINE hasher #-}
+{-# NOINLINE hasher #-}


### PR DESCRIPTION
This use of the `INLINE` pragma is causing nondeterministic hashing behaviour, as discussed in https://github.com/kadena-io/pact/pull/195#issuecomment-417450210. I think the correct course of action is to explicitly `NOINLINE` all functions that use any of the `unsafe*` functions.